### PR TITLE
Allow an option so chef does not downgrade tentacle versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Handles installing Octopus Deploy Server &| Tentacle'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/cvent/octopus-deploy-cookbook'
 issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
-version '0.4.4'
+version '0.4.5'
 
 depends 'windows', '~> 1.38.0'
 supports 'windows'

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -27,6 +27,7 @@ action :install do
   new_resource = @new_resource
   checksum = new_resource.checksum
   version = new_resource.version
+  upgrade_version = new_resource.upgrade_version
 
   verify_version(version)
   verify_checksum(checksum)
@@ -43,7 +44,7 @@ action :install do
   install = windows_package display_name do
     action :install
     source tentacle_installer
-    version version
+    version version if version && upgrade_version
     installer_type :msi
     options '/passive /norestart'
   end
@@ -57,6 +58,7 @@ action :configure do
   instance = new_resource.instance
   checksum = new_resource.checksum
   version = new_resource.version
+  upgrade_version = new_resource.upgrade_version
   home_path = new_resource.home_path
   config_path = new_resource.config_path
   app_path = new_resource.app_path
@@ -70,6 +72,7 @@ action :configure do
     action :install
     checksum checksum
     version version
+    upgrade_version upgrade_version
   end
 
   temp_cert_file = ::File.join(Chef::Config[:file_cache_path], 'temp_config.config')
@@ -129,7 +132,6 @@ end
 
 action :remove do
   new_resource = @new_resource
-  version = new_resource.version
 
   tentacle_installer = ::File.join(Chef::Config[:file_cache_path], 'octopus-tentacle.msi')
 
@@ -139,7 +141,6 @@ action :remove do
 
   remove = windows_package display_name do
     action :remove
-    version version if version
   end
 
   new_resource.updated_by_last_action(actions_updated?([remove, delete]))

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -27,7 +27,7 @@ action :install do
   new_resource = @new_resource
   checksum = new_resource.checksum
   version = new_resource.version
-  upgrade_version = new_resource.upgrade_version
+  enable_upgrades = new_resource.enable_upgrades
 
   verify_version(version)
   verify_checksum(checksum)
@@ -44,7 +44,7 @@ action :install do
   install = windows_package display_name do
     action :install
     source tentacle_installer
-    version version if version && upgrade_version
+    version version if version && enable_upgrades
     installer_type :msi
     options '/passive /norestart'
   end
@@ -58,7 +58,7 @@ action :configure do
   instance = new_resource.instance
   checksum = new_resource.checksum
   version = new_resource.version
-  upgrade_version = new_resource.upgrade_version
+  enable_upgrades = new_resource.enable_upgrades
   home_path = new_resource.home_path
   config_path = new_resource.config_path
   app_path = new_resource.app_path
@@ -72,7 +72,7 @@ action :configure do
     action :install
     checksum checksum
     version version
-    upgrade_version upgrade_version
+    enable_upgrades enable_upgrades
   end
 
   temp_cert_file = ::File.join(Chef::Config[:file_cache_path], 'temp_config.config')

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -27,7 +27,7 @@ action :install do
   new_resource = @new_resource
   checksum = new_resource.checksum
   version = new_resource.version
-  enable_upgrades = new_resource.enable_upgrades
+  upgrades_enabled = new_resource.upgrades_enabled
 
   verify_version(version)
   verify_checksum(checksum)
@@ -44,7 +44,7 @@ action :install do
   install = windows_package display_name do
     action :install
     source tentacle_installer
-    version version if version && enable_upgrades
+    version version if version && upgrades_enabled
     installer_type :msi
     options '/passive /norestart'
   end
@@ -58,7 +58,7 @@ action :configure do
   instance = new_resource.instance
   checksum = new_resource.checksum
   version = new_resource.version
-  enable_upgrades = new_resource.enable_upgrades
+  upgrades_enabled = new_resource.upgrades_enabled
   home_path = new_resource.home_path
   config_path = new_resource.config_path
   app_path = new_resource.app_path
@@ -72,7 +72,7 @@ action :configure do
     action :install
     checksum checksum
     version version
-    enable_upgrades enable_upgrades
+    upgrades_enabled upgrades_enabled
   end
 
   temp_cert_file = ::File.join(Chef::Config[:file_cache_path], 'temp_config.config')

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -31,4 +31,4 @@ attribute :trusted_cert, kind_of: String
 attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
 attribute :cert_file, kind_of: String, default: 'C:\tentacle_cert.txt'
-attribute :upgrade_version, kind_of: [TrueClass, FalseClass], default: true
+attribute :enable_upgrades, kind_of: [TrueClass, FalseClass], default: true

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -31,3 +31,4 @@ attribute :trusted_cert, kind_of: String
 attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
 attribute :cert_file, kind_of: String, default: 'C:\tentacle_cert.txt'
+attribute :upgrade_version, kind_of: [TrueClass, FalseClass], default: true

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -31,4 +31,4 @@ attribute :trusted_cert, kind_of: String
 attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
 attribute :cert_file, kind_of: String, default: 'C:\tentacle_cert.txt'
-attribute :enable_upgrades, kind_of: [TrueClass, FalseClass], default: true
+attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true


### PR DESCRIPTION
Allows the resource to not update if old versions are found.