### PR TITLE
Cleanup tentacle resources and change remove functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,32 @@ end
 
 ### octopus_deploy_tentacle
 #### Actions
-- :install: Install a version of Octopus Deploy Tentacle
-- :remove: Uninstall a version of the Octopus Deploy Tentacle if it is installed
+- :install: Install a version of Octopus Deploy Tentacle (Default)
+- :configure: Configure an instance of the octopus Deploy tentacle
+- :remove: Remove an instance of the Octopus Deploy Tentacle
+- :uninstall: Uninstall a version of the Octopus Deploy Tentacle if it is installed
 
 #### Attribute Parameters
 - :instance: Name attribute. The Octopus Deploy Tentacle instance name (used for configuring the instance not install)
 - :version: Required. The version of Octopus Deploy Tentacle to install
 - :checksum: The SHA256 checksum of the Octopus Deploy Tentacle msi file to verify download
+- :home_path: The Octopus Deploy Instance home directory (Defaults to C:\Octopus)
+- :config_path: The Octopus Deploy Instance config file path (Defaults to C:\Octopus\Tentacle.config)
+- :app_path: The Octopus Deploy Instance application directory (Defaults to C:\Octopus\Applications)
+- :trusted_cert: The Octopus Deploy Instance trusted Server cert
+- :port: The Octopus Deploy Instance port to listen on for listening tentacle (Defaults to 10933)
+- :polling: Whether this Octopus Deploy Instance is a polling tentacle (Defaults to False)
+- :cert_file: Where to export the Octopus Deploy Instance cert (Defaults to C:\Octopus\tentacle_cert.txt)
+- :upgrades_enabled: Whether to upgrade or downgrade the tentacle version if the windows installer version does not match what is provided in the resource. (Defaults to True)
 
 #### Example
-Install version 3.1.1 of Octopus Deploy Tentacle
+Install version 3.2.24 of Octopus Deploy Tentacle
 
 ```ruby
 octopus_deploy_tentacle 'Tentacle' do
   action :install
-  version '3.1.1'
-  checksum '<SHA256-checksum>'
+  version '3.2.24'
+  checksum '147f84241c912da1c8fceaa6bda6c9baf980a77e55e61537880238feb3b7000a'
 end
 
 ```
@@ -59,6 +69,10 @@ end
 ## Assumptions
 
 One major assumption of this cookbook is that you already have .net40 installed on your server.  If you do not then you might need to do that before this cookbook. In addition, some of the resources in here require Chef version 12 in order to work.
+
+
+## Known Issues
+This does not work with Octopus Deploy versions less than 3.2.3 because of a bug in [exporting tentacle certificates](https://github.com/OctopusDeploy/Issues/issues/2143)
 
 
 License and Author

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Handles installing Octopus Deploy Server &| Tentacle'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/cvent/octopus-deploy-cookbook'
 issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
-version '0.4.6'
+version '0.4.7'
 
 depends 'windows', '~> 1.38'
 supports 'windows'

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -144,10 +144,10 @@ action :remove do
       .\\Tentacle.exe delete-instance --instance "#{instance}" --console
       #{catch_powershell_error('Deleting instance from the server')}
     EOH
-    only_if { ::Win32::Service.exists?(service_name) && ::File.exists?(::File.join(tentacle_install_location, "Tentacle.exe")) }
+    only_if { ::Win32::Service.exists?(service_name) && ::File.exist?(tentacle_install_location) }
   end
 
-  remove_config_file = file config_path  do
+  remove_config_file = file config_path do
     action :delete
   end
 

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -18,17 +18,17 @@
 # limitations under the License.
 #
 
-actions :install, :configure, :remove
+actions :install, :configure, :remove, :uninstall
 default_action :install
 
 attribute :instance, kind_of: String, default: 'Tentacle'
 attribute :version, kind_of: String, required: true
 attribute :checksum, kind_of: String
 attribute :home_path, kind_of: String, default: 'C:\Octopus'
-attribute :config_path, kind_of: String, default: 'C:\Octopus\Tentacle.config'
+attribute :config_path, kind_of: String, default: lazy { "#{home_path}\\#{instance}.config" }
 attribute :app_path, kind_of: String, default: 'C:\Octopus\Applications'
 attribute :trusted_cert, kind_of: String
 attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
-attribute :cert_file, kind_of: String, default: 'C:\tentacle_cert.txt'
+attribute :cert_file, kind_of: String, default: lazy { "#{home_path}\\tentacle_cert.txt" }
 attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true

--- a/test/cookbooks/verify-octo/attributes/default.rb
+++ b/test/cookbooks/verify-octo/attributes/default.rb
@@ -19,11 +19,11 @@
 #
 
 # Server test configuration
-default['verify-octo']['server']['version'] = '3.1.3'
-default['verify-octo']['server']['checksum'] = 'c5af09ec60d946a1c6edf564743ffc214f4ff80ff014d35805e18fa3c972da28'
+default['verify-octo']['server']['version'] = '3.2.24'
+default['verify-octo']['server']['checksum'] = 'fe82d0ebd4d0cc9baa38962d8224578154131856a3c3e63621e4834efa3006d7'
 
 # Tentacle test configuration
-default['verify-octo']['tentacle']['version'] = '3.1.3'
-default['verify-octo']['tentacle']['checksum'] = 'c5b4cd6ceec977137d93711ca0ede1dde79ae30da277d70e8d70e6d148860bec'
+default['verify-octo']['tentacle']['version'] = '3.2.24'
+default['verify-octo']['tentacle']['checksum'] = '147f84241c912da1c8fceaa6bda6c9baf980a77e55e61537880238feb3b7000a'
 default['verify-octo']['tentacle']['instance'] = 'Tentacle'
 default['verify-octo']['tentacle']['config_path'] = 'C:\\Octopus\\Tentacle.config'

--- a/test/cookbooks/verify-octo/recipes/tentacle.rb
+++ b/test/cookbooks/verify-octo/recipes/tentacle.rb
@@ -21,7 +21,7 @@
 tentacle = node['verify-octo']['tentacle']
 
 # This section will mock out the certificate creation
-directory "C:\Octopus" do
+directory 'C:\Octopus' do
   action :create
 end
 

--- a/test/cookbooks/verify-octo/recipes/tentacle.rb
+++ b/test/cookbooks/verify-octo/recipes/tentacle.rb
@@ -20,9 +20,19 @@
 
 tentacle = node['verify-octo']['tentacle']
 
+# This section will mock out the certificate creation
+directory "C:\Octopus" do
+  action :create
+end
+
+cookbook_file 'C:\Octopus\tentacle_cert.txt' do
+  action :create
+  source 'cert.txt'
+end
+
 # Just make sure its not installed already
 octopus_deploy_tentacle 'Tentacle' do
-  action :remove
+  action :uninstall
   version tentacle['version']
 end
 
@@ -33,30 +43,10 @@ octopus_deploy_tentacle 'Tentacle' do
   checksum tentacle['checksum']
 end
 
-# This section will mock out the certificate creation
-cert_file = 'C:\tentacle_cert.txt'
-cookbook_file cert_file do
-  action :create
-  source 'cert.txt'
-end
-
-instance = tentacle['instance']
-config_path = tentacle['config_path']
-
-powershell_script "mock-configure-tentacle-#{instance}" do
-  cwd 'C:\Program Files\Octopus Deploy\Tentacle'
-  code <<-EOH
-    .\\Tentacle.exe create-instance --instance="#{instance}" --config="#{config_path}" --console
-    .\\Tentacle.exe import-certificate --instance="#{instance}" -f #{cert_file} --console
-    if ( ! $? ) { throw "ERROR" }
-  EOH
-  not_if { ::File.exist?(config_path) }
-end
-
 octopus_deploy_tentacle 'Tentacle' do
   action :configure
-  version node['verify-octo']['tentacle']['version']
-  checksum node['verify-octo']['tentacle']['checksum']
+  version tentacle['version']
+  checksum tentacle['checksum']
   trusted_cert '324JKSJKLSJ324DSFDF3423FDSF8783FDSFSDFS0'
 end
 


### PR DESCRIPTION
- Allow tentacle to generate cert per machine so it does not change on reconfigure
- Split remove into uninstall and remove
- Remove action now only removes an instance