### PR TITLE
Remove lazy loaded values to fix chef-clients < 12.5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.4.1
   client_rb:
     audit_mode: :enabled
 

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -25,10 +25,10 @@ attribute :instance, kind_of: String, default: 'Tentacle'
 attribute :version, kind_of: String, required: true
 attribute :checksum, kind_of: String
 attribute :home_path, kind_of: String, default: 'C:\Octopus'
-attribute :config_path, kind_of: String, default: lazy { "#{home_path}\\#{instance}.config" }
+attribute :config_path, kind_of: String, default: 'C:\Octopus\Tentacle.config'
 attribute :app_path, kind_of: String, default: 'C:\Octopus\Applications'
 attribute :trusted_cert, kind_of: String
 attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
-attribute :cert_file, kind_of: String, default: lazy { "#{home_path}\\tentacle_cert.txt" }
+attribute :cert_file, kind_of: String, default: 'C:\Octopus\tentacle_cert.txt'
 attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true


### PR DESCRIPTION
- Added chef_omnibus_version to 12.4.1 to make sure this is tested
- Fixes #17