### PR TITLE
Feature/register

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is pre release and there will be major changes to this before its final rel
 - :home_path: The Octopus Deploy Server home directory (Defaults to C:\Octopus)
 - :config_path: The Octopus Deploy Server config file path (Defaults to C:\Octopus\OctopusServer.config)
 - :connection_string: The Octopus Deploy Server connection string to the MSSQL Server instance
-- :master_key: The Octopus Deploy Server master key for encruption, leave blank to generate one at creation
+- :master_key: The Octopus Deploy Server master key for encryption, leave blank to generate one at creation
 - :node_name: The Octopus Deploy Server Node Name, will default to machine hostname
 - :create_database: Whether Octopus Deploy Server should create the database with the connection string provided (Defaults to false)
 - :admin_user: A default admin in AD for the Octopus Deploy Server to create
@@ -47,6 +47,7 @@ end
 #### Actions
 - :install: Install a version of Octopus Deploy Tentacle (Default)
 - :configure: Configure an instance of the octopus Deploy tentacle
+- :register: Register Tentacle with Octopus Deploy Server
 - :remove: Remove an instance of the Octopus Deploy Tentacle
 - :uninstall: Uninstall a version of the Octopus Deploy Tentacle if it is installed
 
@@ -62,6 +63,10 @@ end
 - :polling: Whether this Octopus Deploy Instance is a polling tentacle (Defaults to False)
 - :cert_file: Where to export the Octopus Deploy Instance cert (Defaults to C:\Octopus\tentacle_cert.txt)
 - :upgrades_enabled: Whether to upgrade or downgrade the tentacle version if the windows installer version does not match what is provided in the resource. (Defaults to True)
+- :server: Url to Octopus Deploy Server (e.g https://octopus.example.com)
+- :api_key: Api Key used to register Tentacle to Octopus Server
+- :roles: Array of roles to apply to Tentacle when registering with Octopus Deploy Server (e.g ["web-server","app-server"]) 
+- :environment: Which environment the Tentacle will become part of when registering with Octopus Deploy Server
 
 #### Example
 Install version 3.2.24 of Octopus Deploy Tentacle
@@ -75,6 +80,35 @@ end
 
 ```
 
+```ruby
+Register Listening Tentacle
+# You will first need to generate an api key
+# In Octopus Deploy Server GUI click your Name -> Profile -> API keys
+octopus_deploy_tentacle 'Tentacle' do
+  action :register
+  server 'https://octopus.example.com'
+  api_key '12345678910'
+  roles ['database']
+  environment 'prod'
+end
+```
+
+```ruby
+Register Polling Tentacle
+# You will first need to generate an api key
+# In Octopus Deploy Server GUI click your Name -> Profile -> API keys
+octopus_deploy_tentacle 'Tentacle' do
+  action :register
+  server 'https://octopus.example.com'
+  api_key '12345678910'
+  roles ['web-default']
+  environment 'dev'
+  polling true
+end
+```
+
+
+
 
 ## Assumptions
 
@@ -84,6 +118,11 @@ One major assumption of this cookbook is that you already have .net40 installed 
 ## Known Issues
 This does not work with Octopus Deploy versions less than 3.2.3 because of a bug in [exporting tentacle certificates](https://github.com/OctopusDeploy/Issues/issues/2143)
 
+Tentacle roles are only used the first time a Tentacle is registered with an Octopus Deploy Server. Updating tentacle roles in cookbook will not update roles on Octopus Deploy Server.
+
+Registering multiple tentacles on the same machine is not supported.
+
+Switching Tentacle modes between 'polling' & 'listening' is not currently supported.
 
 License and Author
 ==================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,5 +36,4 @@ default['octopus']['tentacle']['instance']['home_path'] = 'C:\Octopus'
 default['octopus']['tentacle']['instance']['config_file'] = 'C:\Octopus\Tentacle\Tentacle.config'
 default['octopus']['tentacle']['instance']['app_path'] = 'C:\WebApps'
 default['octopus']['tentacle']['instance']['trusted_cert'] = ''
-default['octopus']['tentacle']['instance']['listen_port'] = '10933'
-default['octopus']['tentacle']['instance']['polling'] = 'False'
+default['octopus']['tentacle']['instance']['polling'] = false

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -40,5 +40,17 @@ module OctopusDeploy
     def installer_url(version)
       "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.#{version}-x64.msi"
     end
+
+    def resolve_port(polling, port)
+      port || default_port(polling)
+    end
+
+    def default_port(polling)
+      if polling
+        10_943
+      else
+        10_933
+      end
+    end
   end
 end

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -63,8 +63,8 @@ action :configure do
   config_path = new_resource.config_path
   app_path = new_resource.app_path
   trusted_cert = new_resource.trusted_cert
-  port = new_resource.port
-  polling = fancy_bool(new_resource.polling)
+  polling = new_resource.polling
+  port = resolve_port(polling, new_resource.port)
   service_name = service_name(instance)
   cert_file =  new_resource.cert_file
 
@@ -110,7 +110,7 @@ action :configure do
       #{catch_powershell_error('Generating Certificate if the Import failed')}
       .\\Tentacle.exe configure --instance="#{instance}" --reset-trust --console
       #{catch_powershell_error('Reseting Trust')}
-      .\\Tentacle.exe configure --instance="#{instance}" --home="#{home_path}" --app="#{app_path}" --port="#{port}" --noListen="#{polling}" --console
+      .\\Tentacle.exe configure --instance="#{instance}" --home="#{home_path}" --app="#{app_path}" --port="#{port}" --noListen="#{fancy_bool(polling)}" --console
       #{catch_powershell_error('Configuring instance')}
       .\\Tentacle.exe configure --instance="#{instance}" --trust="#{trusted_cert}" --console
       #{catch_powershell_error('Trusting Octopus Deploy Server')}
@@ -127,6 +127,71 @@ action :configure do
   end
 
   new_resource.updated_by_last_action(actions_updated?([install, create_home_dir, generate_cert, create_instance, configure, service]))
+end
+
+action :register do
+  new_resource = @new_resource
+  instance = new_resource.instance
+  polling = new_resource.polling
+  port = resolve_port(polling, new_resource.port)
+  server = new_resource.server
+  api_key = new_resource.api_key
+  roles = new_resource.roles
+  environment = new_resource.environment
+
+  verify_server(server)
+  verify_api_key(api_key)
+  verify_roles(roles)
+  verify_environment(environment)
+
+  # Itterate over every role and make a big long string like:
+  # --role "web" --role "database" --role "app-server"
+  role_expression = ''
+  roles.each do |a_role|
+    role_expression << "--role \"#{a_role}\" "
+  end
+
+  if polling
+    register_polling_instance = powershell_script "register-polling-tentacle-instance-#{instance}" do
+      action :run
+      cwd tentacle_install_location
+      code <<-EOH
+        .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey "#{api_key}" --comms-style "TentacleActive" --server-comms-port "#{port}" --force --environment "#{environment}" #{role_expression} --console
+        #{catch_powershell_error('Registering Tentacle')}
+      EOH
+      only_if <<-EOH
+        Add-Type -Path '.\\Newtonsoft.Json.dll'
+        Add-Type -Path '.\\Octopus.Client.dll'
+        $endpoint = new-object Octopus.Client.OctopusServerEndpoint '#{server}', '#{api_key}'
+        $repository = new-object Octopus.Client.OctopusRepository $endpoint
+        $tentacle = New-Object Octopus.Client.Model.MachineResource
+        $thumbprint = (& '.\\Tentacle.exe' show-thumbprint --nologo --console)
+        $thumbprint = $thumbprint -replace '.*([A-Z0-9]{40}).*', '$1'
+        [string]::IsNullOrEmpty($thumbprint) -OR $repository.Machines.FindByThumbprint($thumbprint).Thumbprint -ne $thumbprint
+      EOH
+    end
+    new_resource.updated_by_last_action(actions_updated?([register_polling_instance]))
+  else
+    register_listening_instance = powershell_script "register-listening-tentacle-instance-#{instance}" do
+      action :run
+      cwd tentacle_install_location
+      code <<-EOH
+        .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey="#{api_key}" #{role_expression} --environment "#{environment}" --comms-style TentaclePassive --console
+        #{catch_powershell_error('Registering Tentacle')}
+      EOH
+      only_if <<-EOH
+        Add-Type -Path '.\\Newtonsoft.Json.dll'
+        Add-Type -Path '.\\Octopus.Client.dll'
+        $endpoint = new-object Octopus.Client.OctopusServerEndpoint '#{server}', '#{api_key}'
+        $repository = new-object Octopus.Client.OctopusRepository $endpoint
+        $tentacle = New-Object Octopus.Client.Model.MachineResource
+        $thumbprint = (& '.\\Tentacle.exe' show-thumbprint --nologo --console)
+        $thumbprint = $thumbprint -replace '.*([A-Z0-9]{40}).*', '$1'
+        [string]::IsNullOrEmpty($thumbprint) -OR $repository.Machines.FindByThumbprint($thumbprint).Thumbprint -ne $thumbprint
+      EOH
+    end
+    new_resource.updated_by_last_action(actions_updated?([register_listening_instance]))
+  end
 end
 
 action :remove do
@@ -187,4 +252,20 @@ end
 
 def verify_checksum(checksum)
   Chef::Log.warn 'You should include a checksum in the octopus_deploy_tentacle resource for security and performance reasons' unless checksum
+end
+
+def verify_server(server)
+  raise 'A server is required in order to register a Tentacle with Octopus Deploy Server' unless server
+end
+
+def verify_api_key(api_key)
+  raise 'An API key is required in order to register a Tentacle with Octopus Deploy Server' unless api_key
+end
+
+def verify_roles(roles)
+  raise 'At least 1 role is required in order to register a Tentacle with Octopus Deploy Server' if roles.nil? || roles.empty?
+end
+
+def verify_environment(environment)
+  raise 'Environment is required in order to register a Tentacle with Octopus Deploy Server' unless environment
 end

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -18,17 +18,21 @@
 # limitations under the License.
 #
 
-actions :install, :configure, :remove, :uninstall
+actions :install, :configure, :register, :remove, :uninstall
 default_action :install
 
 attribute :instance, kind_of: String, default: 'Tentacle'
-attribute :version, kind_of: String, required: true
+attribute :version, kind_of: String
 attribute :checksum, kind_of: String
 attribute :home_path, kind_of: String, default: 'C:\Octopus'
 attribute :config_path, kind_of: String, default: 'C:\Octopus\Tentacle.config'
 attribute :app_path, kind_of: String, default: 'C:\Octopus\Applications'
 attribute :trusted_cert, kind_of: String
-attribute :port, kind_of: Fixnum, default: 10_933
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
+attribute :port, kind_of: [Fixnum, NilClass], default: nil
 attribute :cert_file, kind_of: String, default: 'C:\Octopus\tentacle_cert.txt'
 attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true
+attribute :server, kind_of: String
+attribute :api_key, kind_of: String
+attribute :roles, kind_of: Array
+attribute :environment, kind_of: String


### PR DESCRIPTION
This is a working addition to register tentacles

Works on both listening & polling nodes. It is documented in the readme and lists known limitations. 
Is properly idempotent by querying the octopus api using powershell and the octopus dll. 

It is robust enough that I think most people should be able to use it as is.


## Known landmines for discussion

- Only tested on Windows 2012R2 with Chef client 12.12.x. 

- Listening tentacles work, but have limited testing because my local octopus deploy can't find the vm on the other side of the virtualbox (test kitchen) NAT. Polling tentacles are well tested.

- Could not get rubocop to work with the linked gist. Gist returns 404, removed from .rubocop.yml

- Adds a dependency on windows_firewall cookbook. 

- [x] Polling & Listening tentacles default to different ports (10933 vs 10943). Adds a new attribute `polling_port` with sane default. **Should `port` be renamed to `listening_port` for consistency?** 

- [x] If the octopus server firewall is blocking inbound 10933 or 10943, the guard interpreter will skip the tentacle registration. **Is this the desired behavior or should the entire chef run fail if tentacle registration fails?** 

- No tests since tentacle registration needs an API token. [While it is possible to generate an api key with powershell, it isn't trivial.](http://help.octopusdeploy.com/discussions/questions/3553-generate-api-key-from-command-line)