### PR TITLE
Add ability for the tentacle resource to setup firewall rule for listening tentacles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This cookbook is used for installing the [Octopus Deploy](http://octopusdeploy.c
 ## NOTICE: Pre-Release
 This is pre release and there will be major changes to this before its final release.  The recipes for installation and configuration will be switched into resources so people can use the library easier. Once this is found stable it will be released as version 1.0.0, until this point lock down to any minor version that you use.
 
-
 ## Resource/Provider
 ### octopus_deploy_server
 #### Actions
@@ -60,6 +59,7 @@ end
 - :app_path: The Octopus Deploy Instance application directory (Defaults to C:\Octopus\Applications)
 - :trusted_cert: The Octopus Deploy Instance trusted Server cert
 - :port: The Octopus Deploy Instance port to listen on for listening tentacle (Defaults to 10933)
+- :configure_firewall: Whether cookbook will open firewall on listen tentacles (Defaults to false)
 - :polling: Whether this Octopus Deploy Instance is a polling tentacle (Defaults to False)
 - :cert_file: Where to export the Octopus Deploy Instance cert (Defaults to C:\Octopus\tentacle_cert.txt)
 - :upgrades_enabled: Whether to upgrade or downgrade the tentacle version if the windows installer version does not match what is provided in the resource. (Defaults to True)
@@ -90,6 +90,7 @@ octopus_deploy_tentacle 'Tentacle' do
   api_key '12345678910'
   roles ['database']
   environment 'prod'
+  configure_firewall true
 end
 ```
 
@@ -102,13 +103,10 @@ octopus_deploy_tentacle 'Tentacle' do
   server 'https://octopus.example.com'
   api_key '12345678910'
   roles ['web-default']
-  environment 'dev'
   polling true
+  environment 'dev'
 end
 ```
-
-
-
 
 ## Assumptions
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
 version '0.5.2'
 
 depends 'windows', '~> 1.38'
+depends 'windows_firewall', '~> 3.0.2'
 supports 'windows'
 
 provides 'octopus_deploy_server[OctopusServer]'

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -29,6 +29,7 @@ attribute :config_path, kind_of: String, default: 'C:\Octopus\Tentacle.config'
 attribute :app_path, kind_of: String, default: 'C:\Octopus\Applications'
 attribute :trusted_cert, kind_of: String
 attribute :polling, kind_of: [TrueClass, FalseClass], default: false
+attribute :configure_firewall, kind_of: [TrueClass, FalseClass], default: false
 attribute :port, kind_of: [Fixnum, NilClass], default: nil
 attribute :cert_file, kind_of: String, default: 'C:\Octopus\tentacle_cert.txt'
 attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true


### PR DESCRIPTION
Adds firewall for tentacle
Since polling tentacles don't need the firewall opened, it only applies to listening tentacles. 
Defaults to 'false'. 

TODO

- [x] Should this default to true or false? 
- [x] Should this be moved to a resource parameter? 

False is safer for existing cookbook users, but is bound to trip up some new users. I've added a new section to the readme making this more obvious. 

Because this is an attribute, some users might have `default['octopus']` while others would have `default['my-octopus']` in their wrapper cookbook

```
default['my-octopus']['tentacle']['instance']['polling']
default['octopus']['tentacle']['instance']['manage_firewall'] = true
```