### PR TITLE
Fixes regression created in #55

### DIFF
--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -149,6 +149,7 @@ action :register do
   roles = new_resource.roles
   environment = new_resource.environment
   config_path = new_resource.config_path
+  service_name = service_name(instance)
 
   verify_server(server)
   verify_api_key(api_key)
@@ -166,6 +167,10 @@ action :register do
     # The other option is to read the registry key but the helpers are not available in 12.4.1
     not_if { tentacle_exists?(server, api_key, tentacle_thumbprint(config_path)) }
     notifies :restart, "windows_service[#{service_name}]", :delayed
+  end
+
+  windows_service service_name do
+    action :nothing
   end
 
   new_resource.updated_by_last_action(actions_updated?([register_instance]))


### PR DESCRIPTION
Fixes the regression that 4f788e299a3aae4b96610dcd8ced863640aa40fe introduced in #55 
Also fixes #55 so tentacles no longer require manual restarts before health checks pass. 


```ruby
         * octopus_deploy_tentacle[Tentacle] action configure
           * windows_firewall_rule[Octopus Deploy Tentacle] action create (skipped due to only_if)
           * octopus_deploy_tentacle[Tentacle] action install[2016-08-18T00:01:28+00:00] WARN: Please use the package resource available in Chef Client 12.6.
       windows_package will be removed in the next major version release
       of the Windows cookbook.


             * remote_file[C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache/octopus-tentacle.msi] action create (up to date)
             * windows_package[Octopus Deploy Tentacle] action install (up to date)
       (up to date)
           * directory[C:\Octopus] action create (up to date)
           * powershell_script[generate-tentacle-cert] action run (skipped due to not_if)
           * powershell_script[create-instance-Tentacle] action run (skipped due to not_if)
           * powershell_script[configure-tentacle-Tentacle] action run (skipped due to not_if)
           * windows_service[OctopusDeploy Tentacle] action enable (up to date)
           * windows_service[OctopusDeploy Tentacle] action start (up to date)
            (up to date)
         * octopus_deploy_tentacle[Tentacle] action register
           * powershell_script[register-Tentacle-tentacle] action run
             - execute "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -File "C:/Users/ADMINI~1/AppData/Local/Temp/chef-script20160818-2168-1j55eel.ps1"
           * windows_service[OctopusDeploy Tentacle] action nothing (skipped due to action :nothing)
           * windows_service[OctopusDeploy Tentacle] action restart
             - restart service windows_service[OctopusDeploy Tentacle]

```

Green checkmark means health check passed. 

<img width="390" alt="screenshot 2016-08-17 18 09 25" src="https://cloud.githubusercontent.com/assets/242382/17757646/c01220ac-64a5-11e6-9931-3c6313f92bb8.png">


The git history is now a little messy. If you prefer, you could revert #55 and we can combine it with #57. Otherwise it should be good as is.