### PR TITLE
Fix option_list methods handling of nils

### DIFF
--- a/libraries/shared.rb
+++ b/libraries/shared.rb
@@ -28,7 +28,7 @@ module OctopusDeploy
     # Iterate over every option and make a big long string like:
     # --role "web" --role "database" --role "app-server"
     def option_list(name, options)
-      options.map { |option| "--#{name} \"#{option}\"" }.join(' ')
+      options.map { |option| "--#{name} \"#{option}\"" }.join(' ') if name && options
     end
 
     def installer_options

--- a/spec/unit/lib_shared_spec.rb
+++ b/spec/unit/lib_shared_spec.rb
@@ -17,6 +17,18 @@ describe 'OctopusDeploy::Shared' do
       options = %w(option1 option2)
       expect(shared.option_list(name, options)).to eq '--name "option1" --name "option2"'
     end
+
+    it 'should return nil if name is nil' do
+      name = nil
+      options = '42'
+      expect(shared.option_list(name, options)).to eq nil
+    end
+
+    it 'should return nil if options is nil' do
+      name = 'foo'
+      options = nil
+      expect(shared.option_list(name, options)).to eq nil
+    end
   end
 
   describe 'installer_options' do


### PR DESCRIPTION
### Description

If `option_list` function in libraries/shared.rb is given a non existant attribute, it will cause chef run to fail. 
By allowing option_list to be given nil parameters, it allows optional attributes to be defined. (e.g tenant and tentanttag which will be arriving in another pull request). 

### Issues Resolved

#59 

### Contribution Check List
- [x] All tests pass.
- [x] New functionality includes testing.

