### PR TITLE
Adds tenant and tentanttag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ end
 - :api_key: Api Key used to register Tentacle to Octopus Server
 - :roles: Array of roles to apply to Tentacle when registering with Octopus Deploy Server (e.g ["web-server","app-server"]) 
 - :environment: Which environment the Tentacle will become part of when registering with Octopus Deploy Server (Defaults to node.chef_environment )
-
+- :tenants: Optional array of tenants to add to the tentacle. Tenant must already exist on Octopus Deploy Server. Requires Octopus 3.4
+- :tenant_tags: Optional array of tenant tags to add to the tentacle. Tags must already exist on Octopus Deploy Server. Requires Octopus 3.4
 
 #### Examples
 

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -150,6 +150,8 @@ action :register do
   environment = new_resource.environment
   config_path = new_resource.config_path
   service_name = service_name(instance)
+  tenants = new_resource.tenants
+  tenant_tags = new_resource.tenant_tags
 
   verify_server(server)
   verify_api_key(api_key)
@@ -160,7 +162,7 @@ action :register do
     action :run
     cwd tentacle_install_location
     code <<-EOH
-      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} --environment "#{environment}" #{option_list('role', roles)} --console
+      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} --environment "#{environment}" #{option_list('role', roles)} #{option_list('tenant', tenants)} #{option_list('tenanttag', tenant_tags)} --console
       #{catch_powershell_error('Registering Tentacle')}
     EOH
     # This is sort of a hack, you need to specify the config_path on register if it is not default

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -37,3 +37,5 @@ attribute :server, kind_of: String
 attribute :api_key, kind_of: String
 attribute :roles, kind_of: Array
 attribute :environment, kind_of: String, default: node.chef_environment
+attribute :tenants, kind_of: Array, default: nil
+attribute :tenant_tags, kind_of: Array, default: nil


### PR DESCRIPTION
### Description

Allows cookbook to add a machine to a tenant or add tenant tags

I've manually tested this. Not sure how to automate testing this. 

### Contribution Check List
- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README.

