### PR TITLE
Allow multiple environments when registering tentacles

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ end
 - :server: Url to Octopus Deploy Server (e.g https://octopus.example.com)
 - :api_key: Api Key used to register Tentacle to Octopus Server
 - :roles: Array of roles to apply to Tentacle when registering with Octopus Deploy Server (e.g ["web-server","app-server"]) 
-- :environment: Which environment the Tentacle will become part of when registering with Octopus Deploy Server (Defaults to node.chef_environment )
+- :environment: Which environment or environments the Tentacle will become part of when registering with Octopus Deploy Server (Defaults to node.chef_environment). Accepts string or array.
 - :tenants: Optional array of tenants to add to the tentacle. Tenant must already exist on Octopus Deploy Server. Requires Octopus 3.4
 - :tenant_tags: Optional array of tenant tags to add to the tentacle. Tags must already exist on Octopus Deploy Server. Requires Octopus 3.4
 

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -147,7 +147,7 @@ action :register do
   server = new_resource.server
   api_key = new_resource.api_key
   roles = new_resource.roles
-  environment = new_resource.environment
+  environment = Array(new_resource.environment)
   config_path = new_resource.config_path
   service_name = service_name(instance)
   tenants = new_resource.tenants
@@ -162,7 +162,7 @@ action :register do
     action :run
     cwd tentacle_install_location
     code <<-EOH
-      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} --environment "#{environment}" #{option_list('role', roles)} #{option_list('tenant', tenants)} #{option_list('tenanttag', tenant_tags)} --console
+      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{node.name}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} #{option_list('environment', environment)} #{option_list('role', roles)} #{option_list('tenant', tenants)} #{option_list('tenanttag', tenant_tags)} --console
       #{catch_powershell_error('Registering Tentacle')}
     EOH
     # This is sort of a hack, you need to specify the config_path on register if it is not default
@@ -251,5 +251,5 @@ def verify_roles(roles)
 end
 
 def verify_environment(environment)
-  raise 'Environment is required in order to register a Tentacle with Octopus Deploy Server' unless environment
+  raise 'At least 1 environment is required in order to register a Tentacle with Octopus Deploy Server' if environment.nil? || environment.empty?
 end

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -36,6 +36,6 @@ attribute :upgrades_enabled, kind_of: [TrueClass, FalseClass], default: true
 attribute :server, kind_of: String
 attribute :api_key, kind_of: String
 attribute :roles, kind_of: Array
-attribute :environment, kind_of: String, default: node.chef_environment
+attribute :environment, kind_of: [String, Array], default: node.chef_environment
 attribute :tenants, kind_of: Array, default: nil
 attribute :tenant_tags, kind_of: Array, default: nil


### PR DESCRIPTION
### Description

This allows multiple environments for a tentacle

### Contribution Check List
- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README.

