### PR TITLE
Added the 'public_dns' attribute which sets the '--publicHostName' sw…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ end
 - :tentacle_name: Optional custom name for Tentacle. Defaults to the Chef node name
 - :service_user: Optional service user name. Defaults to Local System
 - :service_password: Password for service user
+- :public_dns: Optional DNS/IP value to use when registring with the octopus server. Defaults to node['fqdn']
 
 #### Examples
 

--- a/providers/tentacle.rb
+++ b/providers/tentacle.rb
@@ -158,6 +158,7 @@ action :register do
   tenants = new_resource.tenants
   tenant_tags = new_resource.tenant_tags
   tentacle_name = new_resource.tentacle_name
+  public_dns = new_resource.public_dns
 
   verify_server(server)
   verify_api_key(api_key)
@@ -168,7 +169,7 @@ action :register do
     action :run
     cwd tentacle_install_location
     code <<-EOH
-      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{tentacle_name}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} #{option_list('environment', environment)} #{option_list('role', roles)} #{option_list('tenant', tenants)} #{option_list('tenanttag', tenant_tags)} --console
+      .\\Tentacle.exe register-with --instance "#{instance}" --server "#{server}" --name "#{tentacle_name}" --publicHostName "#{public_dns}" --apiKey "#{api_key}" #{register_comm_config(polling, port)} #{option_list('environment', environment)} #{option_list('role', roles)} #{option_list('tenant', tenants)} #{option_list('tenanttag', tenant_tags)} --console
       #{catch_powershell_error('Registering Tentacle')}
     EOH
     # This is sort of a hack, you need to specify the config_path on register if it is not default

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -42,3 +42,4 @@ attribute :tenant_tags, kind_of: Array, default: nil
 attribute :tentacle_name, kind_of: String, default: node.name
 attribute :service_user, kind_of: String, default: nil
 attribute :service_password, kind_of: String, default: nil
+attribute :public_dns, kind_of: String, default: node['fqdn']


### PR DESCRIPTION
### Description

This allows Tentacles to register with the Octopus server using an IP or DNS that is separate from the Hostname. This is useful when the hostname of a node is not resolvable from the Octopus server.


### Contribution Check List
- [X] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README.

