### PR TITLE
Adds minor version pin to windows firewall

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
 version '0.9.0'
 
 depends 'windows', '>= 1.38.0'
-depends 'windows_firewall', '~> 3.0'
+depends 'windows_firewall', '~> 3.0.0'
 supports 'windows'
 
 provides 'octopus_deploy_server[OctopusServer]'


### PR DESCRIPTION
I've seen very weird things happen when trying to mix 2 number version pins when the cookbook uses 3 number versioning. 

Since the windows_firewall cookbook uses the 3 dot syntax, this is safer. 