### PR TITLE
Removes the Server resources delayed restart

### DIFF
--- a/providers/server.rb
+++ b/providers/server.rb
@@ -110,7 +110,6 @@ action :configure do
     #{catch_powershell_error('Create Service')}
     EOH
     sensitive !debug
-    notifies :restart, "windows_service[#{service_name}]", :delayed if start_service
     not_if { ::Win32::Service.exists?(service_name) }
   end
 


### PR DESCRIPTION
The delayed restart when a service is configured was causing issues
because the service would be started, then restarted shortly after.
This removes that restart which is unncessesary anyway. Fixes #82