### PR TITLE
Fix for Chef 13 not accepting name_attribute and default on a resourc…

### DIFF
--- a/resources/tools.rb
+++ b/resources/tools.rb
@@ -22,6 +22,6 @@
 actions :install
 default_action :install
 
-attribute :path, kind_of: String, default: 'C:\\octopus', name_attribute: true
+attribute :path, kind_of: String, default: 'C:\\octopus'
 attribute :source, kind_of: String, required: true
 attribute :checksum, kind_of: String


### PR DESCRIPTION
### Description
Fix for Chef 13 not accepting both name_attribute and default on a resource attribute
[Describe what this change achieves along with any notes about the change that are relevant]

### Issues Resolved
resolve #88 

### Contribution Check List
- [x] All tests pass.
- [x] n/a New functionality includes testing.
- [x] n/a New functionality has been documented in the README.
