### PR TITLE
Adds chef_version requirement to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ provides 'octopus_deploy_server[OctopusServer]'
 provides 'octopus_deploy_tentacle[Tentacle]'
 provides 'octopus_deploy_tools[C:\octopus]'
 
-chef_version '>= 12.5.0'
+chef_version '>= 12.5.0' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ supports 'windows'
 provides 'octopus_deploy_server[OctopusServer]'
 provides 'octopus_deploy_tentacle[Tentacle]'
 provides 'octopus_deploy_tools[C:\octopus]'
+
+chef_version '>= 12.5.0'


### PR DESCRIPTION
Now that cookbook uses custom resources, make clear that this requires chef 12.5.0
