### PR TITLE
Bump windows cookbook dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,6 @@ source 'https://supermarket.chef.io/'
 metadata
 
 group :test do
+  cookbook 'windows', '~> 3.0.5'
   cookbook 'octopus-deploy-test', path: './test/cookbooks/octopus-deploy-test'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ source_url 'https://github.com/cvent/octopus-deploy-cookbook'
 issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
 version '0.12.0'
 
-depends 'windows', '>= 1.38.0'
+depends 'windows'
 depends 'windows_firewall', '~> 3.0'
 supports 'windows'
 


### PR DESCRIPTION
Resolves issue #29 
Bump windows cookbook version now that `windows_package` is part of chef 12. 
Windows cookbook 3.0.x no longer includes windows_package resource. 

I intentionally didn't upgrade to 3.1.x since that version of the windows cookbook requires chef 12.7.x

The `windows_zipfile` has no breaking changes so there should be no change in behavior. 

https://github.com/chef-cookbooks/windows/blob/master/CHANGELOG.md

