### PR TITLE
Bump chef_version in metadata to 12.6.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ provides 'octopus_deploy_server[OctopusServer]'
 provides 'octopus_deploy_tentacle[Tentacle]'
 provides 'octopus_deploy_tools[C:\octopus]'
 
-chef_version '>= 12.5.0' if respond_to?(:chef_version)
+chef_version '>= 12.6.0' if respond_to?(:chef_version)


### PR DESCRIPTION
Should have bumped the chef version requirement to 12.6.0 since that is the version that the windows_package resource was moved to core

>WARN: Please use the package resource available in Chef Client 12.6. windows_package will be removed in the next major version release