### PR TITLE
Use Powershell instead of chef api for api call

### DIFF
--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -49,11 +49,8 @@ module OctopusDeploy
     def tentacle_exists?(server, api_key, thumbprint)
       if node['platform_family'] == 'windows'
         stdout = powershell_out(get_all_tentacles(server, api_key, thumbprint)).stdout.chomp
-        if stdout == thumbprint
-          return true
-        else
-          return false
-        end
+        return false unless stdout == thumbprint
+        return true
       else
         ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
           machine['Thumbprint'] == thumbprint
@@ -62,11 +59,11 @@ module OctopusDeploy
     end
 
     def get_all_tentacles(server, api_key, thumbprint)
-      %Q{
+      %(
         $url = '#{server}' + '/api/machines/all?thumbprint=' + '#{thumbprint}'
         $result = Invoke-RestMethod -Method Get -Uri $url -Headers @{'X-Octopus-ApiKey' = '#{api_key}'}
         $result.thumbprint
-      }
+      )
     end
 
     def tentacle_thumbprint(config)

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -47,14 +47,8 @@ module OctopusDeploy
     end
 
     def tentacle_exists?(server, api_key, thumbprint)
-      if node['platform_family'] == 'windows'
-        stdout = powershell_out(get_all_tentacles(server, api_key, thumbprint)).stdout.chomp
-        stdout != thumbprint
-      else
-        ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
-          machine['Thumbprint'] == thumbprint
-        end
-      end
+      stdout = powershell_out(get_all_tentacles(server, api_key, thumbprint)).stdout.chomp
+      stdout != thumbprint
     end
 
     def get_all_tentacles(server, api_key, thumbprint)

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -47,9 +47,26 @@ module OctopusDeploy
     end
 
     def tentacle_exists?(server, api_key, thumbprint)
-      ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
-        machine['Thumbprint'] == thumbprint
+      if node['platform_family'] == 'windows'
+        stdout = powershell_out(get_all_tentacles(server, api_key, thumbprint)).stdout.chomp
+        if stdout == thumbprint
+          return true
+        else
+          return false
+        end
+      else
+        ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
+          machine['Thumbprint'] == thumbprint
+        end
       end
+    end
+
+    def get_all_tentacles(server, api_key, thumbprint)
+      %Q{
+        $url = '#{server}' + '/api/machines/all?thumbprint=' + '#{thumbprint}'
+        $result = Invoke-RestMethod -Method Get -Uri $url -Headers @{'X-Octopus-ApiKey' = '#{api_key}'}
+        $result.thumbprint
+      }
     end
 
     def tentacle_thumbprint(config)

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -49,8 +49,7 @@ module OctopusDeploy
     def tentacle_exists?(server, api_key, thumbprint)
       if node['platform_family'] == 'windows'
         stdout = powershell_out(get_all_tentacles(server, api_key, thumbprint)).stdout.chomp
-        return false unless stdout == thumbprint
-        return true
+        stdout != thumbprint
       else
         ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
           machine['Thumbprint'] == thumbprint

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -25,6 +25,7 @@ module OctopusDeploy
   # A container to hold the tentacle values instead of attributes
   module Tentacle
     include OctopusDeploy::Shared
+    include Chef::Mixin::PowershellOut
 
     def display_name
       'Octopus Deploy Tentacle'

--- a/spec/unit/lib_tentacle_spec.rb
+++ b/spec/unit/lib_tentacle_spec.rb
@@ -27,24 +27,6 @@ describe 'OctopusDeploy::Tentacle' do
     end
   end
 
-  describe 'tentacle_exists?' do
-    it 'should return true if the tentacle exists' do
-      stub_request(:get, 'https://octopus.com/api/machines/all?thumbprint=1234')
-        .to_return(status: 200, body: '[{"Thumbprint": "1234"}]')
-
-      exists = tentacle.tentacle_exists?('https://octopus.com', 'API-key', '1234')
-      expect(exists).to eq true
-    end
-
-    it 'should return false if the tentacle doesnt exist' do
-      stub_request(:get, 'https://octopus.com/api/machines/all?thumbprint=1234')
-        .to_return(status: 200, body: '[]')
-
-      exists = tentacle.tentacle_exists?('https://octopus.com', 'API-key', '1234')
-      expect(exists).to eq false
-    end
-  end
-
   describe 'tentacle_thumbprint' do
     it 'should return nil if the file does not exist' do
       allow(::File).to receive(:exist?).with('file').and_return(false)


### PR DESCRIPTION
### Description

For Windows Servers change from the builtin Chef `Chef::HTTP` to Powershell `Invoke-RestMethod`. This makes it easier to use Self signed Certificates(on the Octopus Server) from the Windows Local Machine certificate store. Alternative is to add your generated cert to "C:\opscode\chef\embedded\ssl\certs\cacert.pem" to make OpenSSL happy, but we would rather manage root certs in one place(windows cert store) not two.

### Issues Resolved

### Contribution Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README.
