### PR TITLE
Add tentacle install_url to override default installer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is pre release and there will be major changes to this before its final rel
 - :version: Required. The version of Octopus Deploy Server to install
 - :checksum: The SHA256 checksum of the Octopus Deploy Server msi file to verify download
 - :home_path: The Octopus Deploy Server home directory (Defaults to C:\Octopus)
+- :install_url: The url for the installer to download.
 - :config_path: The Octopus Deploy Server config file path (Defaults to C:\Octopus\OctopusServer.config)
 - :connection_string: The Octopus Deploy Server connection string to the MSSQL Server instance. Required for `:configure` action.
 - :master_key: The Octopus Deploy Server master key for encryption, leave blank to generate one at creation

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -42,7 +42,9 @@ module OctopusDeploy
       'C:\Program Files\Octopus Deploy\Tentacle'
     end
 
-    def installer_url(version)
+    def installer_url(version, url)
+      return url if url
+
       "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.#{version}-x64.msi"
     end
 

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -27,6 +27,7 @@ property :instance, String, default: 'Tentacle'
 property :version, String
 property :checksum, String
 property :home_path, String, default: 'C:\Octopus'
+property :install_url, [String, nil], default: nil
 property :config_path, String, default: 'C:\Octopus\Tentacle.config'
 property :app_path, String, default: 'C:\Octopus\Applications'
 property :trusted_cert, String
@@ -49,11 +50,11 @@ property :public_dns, String, default: node['fqdn']
 default_action :install
 
 action :install do
-  verify_version(new_resource.version)
+  verify_version(new_resource.version, new_resource.install_url)
   verify_checksum(new_resource.checksum)
 
   tentacle_installer = ::File.join(Chef::Config[:file_cache_path], 'octopus-tentacle.msi')
-  install_url = installer_url(new_resource.version)
+  install_url = installer_url(new_resource.version, new_resource.install_url)
 
   remote_file tentacle_installer do
     action :create
@@ -200,8 +201,8 @@ action :uninstall do
   end
 end
 
-def verify_version(version)
-  raise 'A version is required in order to install Octopus Deploy Tentacle' unless version
+def verify_version(version, installer_url)
+  raise 'A version or installer_url is required in order to install Octopus Deploy Tentacle' unless version || installer_url
 end
 
 def verify_checksum(checksum)

--- a/spec/unit/lib_tentacle_spec.rb
+++ b/spec/unit/lib_tentacle_spec.rb
@@ -62,8 +62,12 @@ describe 'OctopusDeploy::Tentacle' do
   end
 
   describe 'installer_url' do
-    it 'should return the correct installer url' do
-      expect(tentacle.installer_url('3.2.1')).to eq 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.2.1-x64.msi'
+    it 'should return the correct install url if no installer_url is set' do
+      expect(tentacle.installer_url('3.2.1', nil)).to eq 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.2.1-x64.msi'
+    end
+
+    it 'should return the specified installer_url if one is provided' do
+      expect(tentacle.installer_url('3.2.1', 'https://overridden.com/Octopus.Tentacle.3.2.1-x64.msi')).to eq 'https://overridden.com/Octopus.Tentacle.3.2.1-x64.msi'
     end
   end
 

--- a/test/cookbooks/octopus-deploy-test/attributes/default.rb
+++ b/test/cookbooks/octopus-deploy-test/attributes/default.rb
@@ -27,6 +27,7 @@ default['octopus-deploy-test']['server']['connection-string'] = 'Server=(local)\
 
 # Tentacle test configuration
 default['octopus-deploy-test']['tentacle']['version'] = '3.16.3'
+default['octopus-deploy-test']['tentacle']['installer_url'] = 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.16.3-x64.msi'
 default['octopus-deploy-test']['tentacle']['checksum'] = 'c6874bb29fe8550f275f879264fa60c9b196b39cc97d3148f969c3cc3341d440'
 default['octopus-deploy-test']['tentacle']['instance'] = 'Tentacle'
 default['octopus-deploy-test']['tentacle']['config_path'] = 'C:\\Octopus\\Tentacle.config'

--- a/test/cookbooks/octopus-deploy-test/recipes/tentacle.rb
+++ b/test/cookbooks/octopus-deploy-test/recipes/tentacle.rb
@@ -55,7 +55,7 @@ end
 octopus_deploy_tentacle 'configure TentacleWithUser' do
   action [:remove, :configure]
   instance 'TentacleWithUser'
-  version tentacle['version']
+  install_url tentacle['installer_url']
   checksum tentacle['checksum']
   polling true
   trusted_cert '324JKSJKLSJ324DSFDF3423FDSF8783FDSFSDFS0'


### PR DESCRIPTION
This allows you to override the installer url instead of just using the version on the octopus deploy download pages.

### Description

[Describe what this change achieves along with any notes about the change that are relevant]

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List
- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README.
