### PR TITLE
Fix issue #134

### DIFF
--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -157,7 +157,7 @@ action :register do
     action :run
     cwd tentacle_install_location
     code <<-EOH
-      .\\Tentacle.exe register-with --instance "#{new_resource.instance}" --server "#{new_resource.server}" --name "#{new_resource.tentacle_name}" --publicHostName "#{new_resource.public_dns}" --apiKey "#{new_resource.api_key}" #{register_comm_config(new_resource.polling, port)} #{option_list('environment', environment)} #{option_list('role', new_resource.roles)} #{option_list('tenant', new_resource.tenants)} #{option_list('tenanttag', new_resource.tenant_tags)} #{option_list('tenanted-deployment-participation', new_resource.tenated_deployment_participation)} --console
+      .\\Tentacle.exe register-with --instance "#{new_resource.instance}" --server "#{new_resource.server}" --name "#{new_resource.tentacle_name}" --publicHostName "#{new_resource.public_dns}" --apiKey "#{new_resource.api_key}" #{register_comm_config(new_resource.polling, port)} #{option_list('environment', environment)} #{option_list('role', new_resource.roles)} #{option_list('tenant', new_resource.tenants)} #{option_list('tenanttag', new_resource.tenant_tags)} #{option_list('tenanted-deployment-participation', new_resource.tenated_deployment_participation.to_s)} --console
       #{catch_powershell_error('Registering Tentacle')}
     EOH
     # This is sort of a hack, you need to specify the config_path on register if it is not default


### PR DESCRIPTION
Should fix issue #134 (not tested)

I decided to use symbols since they should never change. Perhaps strings would be better. 

This converts the symbols to strings before the map `new_resource.tenated_deployment_participation.to_s`

I'm still not sure why the appveyor tests aren't catching this. 