### PR TITLE
Disable tentacle proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Berksfile.lock
 vendor/
 .rubocop-http*
 coverage/
+
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development do
   gem 'berkshelf'
   gem 'codecov'
   gem 'webmock'
+  gem 'nokogiri'
 end
 
 group :appveyor do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     octokit (4.8.0)
@@ -394,10 +394,11 @@ DEPENDENCIES
   kitchen-inspec
   kitchen-localhost
   kitchen-vagrant
+  nokogiri
   rake (< 11)
   rspec
   stove
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -80,5 +80,13 @@ module OctopusDeploy
         10_933
       end
     end
+
+    def proxy_command(polling)
+      if polling
+        'polling-proxy'
+      else
+        'proxy'
+      end
+    end
   end
 end

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -118,6 +118,8 @@ action :configure do
       #{catch_powershell_error('Configuring instance')}
       .\\Tentacle.exe configure --instance="#{new_resource.instance}" --trust="#{new_resource.trusted_cert}" --console
       #{catch_powershell_error('Trusting Octopus Deploy Server')}
+      .\\Tentacle.exe #{proxy_command(new_resource.polling)} --instance="#{new_resource.instance}" --proxyEnable=False
+      #{catch_powershell_error('Configuring proxy')}
       .\\Tentacle.exe service --instance="#{new_resource.instance}" --install --console
       #{catch_powershell_error('Installing Service')}
     EOH

--- a/resources/tools.rb
+++ b/resources/tools.rb
@@ -21,9 +21,9 @@
 
 resource_name 'octopus_deploy_tools'
 
-property :path, kind_of: String, name_attribute: true
-property :source, kind_of: String, required: true
-property :checksum, kind_of: String
+property :path, String, name_property: true
+property :source, String, required: true
+property :checksum, String
 
 default_action :install
 

--- a/spec/unit/lib_tentacle_spec.rb
+++ b/spec/unit/lib_tentacle_spec.rb
@@ -94,4 +94,14 @@ describe 'OctopusDeploy::Tentacle' do
       expect(tentacle.resolve_port(false)).to eq 10_933
     end
   end
+
+  describe 'proxy_command' do
+    it 'should return Polling proxy for polling tentacle' do
+      expect(tentacle.proxy_command(true)).to eq 'polling-proxy'
+    end
+
+    it 'should return Proxy for non-polling tentacle' do
+      expect(tentacle.proxy_command(false)).to eq 'proxy'
+    end
+  end
 end


### PR DESCRIPTION
### Description

This PR disables the proxy setting recently added to the Tentacle.

If proxy settings are required, this will need to be added to the `octopus_deploy_tentacle` resource

### Issues Resolved

None

### Contribution Check List
- [x] All tests pass.
- [x] New functionality includes testing.
- N/A -  New functionality has been documented in the README.