### PR TITLE
Escape spaces in certificate file

### DIFF
--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -108,7 +108,7 @@ action :configure do
     cwd tentacle_install_location
     sensitive new_resource.sensitive
     code <<-EOH
-      .\\Tentacle.exe import-certificate --instance="#{new_resource.instance}" -f #{new_resource.cert_file} --console
+      .\\Tentacle.exe import-certificate --instance="#{new_resource.instance}" --from-file="#{new_resource.cert_file}" --console
       #{catch_powershell_error('Importing Certificate that was generated for the machine')}
       .\\Tentacle.exe new-certificate --instance="#{new_resource.instance}" --if-blank --console
       #{catch_powershell_error('Generating Certificate if the Import failed')}

--- a/test/cookbooks/octopus-deploy-test/recipes/tentacle.rb
+++ b/test/cookbooks/octopus-deploy-test/recipes/tentacle.rb
@@ -21,8 +21,12 @@
 
 tentacle = node['octopus-deploy-test']['tentacle']
 
-# This section will mock out the certificate creation
-cert_file = 'C:\tentacle_cert.txt'
+# This section will mock out the certificate creationa
+cert_directory = 'C:\Octopus Certificate'
+cert_file = File.join(cert_directory, 'tentacle_cert.txt')
+
+directory cert_directory
+
 cookbook_file cert_file do
   action :create
   source 'cert.txt'


### PR DESCRIPTION
### Description

Currently, the `import-certificate` command passes the `cert_file` parameter in without quotes - which causes powershell errors if the certificate lives in a directory that contains spaces (example: `C:\Program Files\Tentacle`). Quoting the path (as is done elsewhere in the resource) fixes this problem. Also switch to using the full argument name, which seems to be the standard for most other arguments.

This may be an issue in other places, like `libraries/server_scripts.rb`.

Unsure if the test change is necessary - happy to remove it if you think it's overkill 🙂 

### Issues Resolved

N/A

### Contribution Check List
- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README.
