### PR TITLE
feat: bump versions of octo server and tentacle

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,7 +21,7 @@ suites:
     attributes:
       octopus-deploy-test:
         server:
-          create-database: false
+          create-database: true
           start-service: false
   - name: tentacle
     run_list:

--- a/libraries/server_scripts.rb
+++ b/libraries/server_scripts.rb
@@ -71,9 +71,9 @@ class ServerScripts < TemplateScripts
         --console
       <%= catch_powershell_error('Configuring Home Dir') %>
 
-      .\\Octopus.Server.exe configure `
+      .\\Octopus.Server.exe database `
         <%= option('instance', resource.instance) %> `
-        <%= option('storageConnectionString', resource.connection_string) %> `
+        <%= option('connectionString', resource.connection_string) %> `
         --console
       <%= catch_powershell_error('Configuring Database Connection') %>
 

--- a/libraries/server_scripts.rb
+++ b/libraries/server_scripts.rb
@@ -74,8 +74,9 @@ class ServerScripts < TemplateScripts
       .\\Octopus.Server.exe database `
         <%= option('instance', resource.instance) %> `
         <%= option('connectionString', resource.connection_string) %> `
+        <% if resource.create_database %>--create<% end %> `
         --console
-      <%= catch_powershell_error('Configuring Database Connection') %>
+      <%= resource.create_database ? catch_powershell_error('Create Database Connection') : catch_powershell_error('Configuring Database Connection') %>
 
       .\\Octopus.Server.exe configure `
         <%= option('instance', resource.instance) %> `
@@ -110,14 +111,6 @@ class ServerScripts < TemplateScripts
           <%= option('masterkey', resource.master_key) %> `
           --console
         <%= catch_powershell_error('Configuring Master Key') %>
-      <% end %>
-
-      <% if resource.create_database %>
-        .\\Octopus.Server.exe database `
-          <%= option('instance', resource.instance) %> `
-          --create `
-          --console
-        <%= catch_powershell_error('Create Database') %>
       <% end %>
 
       .\\Octopus.Server.exe service `

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -33,6 +33,8 @@ property :master_key, String
 property :node_name, String, default: node.name
 property :create_database, [true, false], default: false
 property :admin_user, String
+property :user, String, default: nil
+property :password, String, sensitive: true, default: nil
 property :license, String
 property :start_service, [true, false], default: true
 
@@ -75,6 +77,8 @@ action :configure do
     action :run
     cwd server_install_location
     sensitive new_resource.sensitive
+    user new_resource.user
+    password new_resource.password
     code scripts.configure_instance(new_resource)
     not_if { ::Win32::Service.exists?(service_name) }
   end

--- a/test/cookbooks/octopus-deploy-test/attributes/default.rb
+++ b/test/cookbooks/octopus-deploy-test/attributes/default.rb
@@ -20,14 +20,14 @@
 #
 
 # Server test configuration
-default['octopus-deploy-test']['server']['version'] = '3.2.24'
-default['octopus-deploy-test']['server']['checksum'] = 'fe82d0ebd4d0cc9baa38962d8224578154131856a3c3e63621e4834efa3006d7'
+default['octopus-deploy-test']['server']['version'] = '2018.7.2'
+default['octopus-deploy-test']['server']['checksum'] = '89645C258354DE1C8038B5AD630E2EB8F3F1ECE096699A17300636BD116C2423'
 default['octopus-deploy-test']['server']['master-key'] = 'wJ+qLI8AjSvtdtIt05eW7w=='
 default['octopus-deploy-test']['server']['connection-string'] = 'Server=(local)\SQL2016;Database=master;User ID=sa;Password=Password12!'
 
 # Tentacle test configuration
-default['octopus-deploy-test']['tentacle']['version'] = '3.19.0'
-default['octopus-deploy-test']['tentacle']['installer_url'] = 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.19.0-x64.msi'
-default['octopus-deploy-test']['tentacle']['checksum'] = 'a37b6c16494f16e7de03566de737a8c437267a227e287ed2f3f4d0ecab9eadee'
+default['octopus-deploy-test']['tentacle']['version'] = '3.22.0'
+default['octopus-deploy-test']['tentacle']['installer_url'] = 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.22.0-x64.msi'
+default['octopus-deploy-test']['tentacle']['checksum'] = '197AB79A95ADEE15AB0058BF0FA73D9E8AF2AA6AEF1741BEB39170C3A1D72CAB'
 default['octopus-deploy-test']['tentacle']['instance'] = 'Tentacle'
 default['octopus-deploy-test']['tentacle']['config_path'] = 'C:\\Octopus\\Tentacle.config'

--- a/test/cookbooks/octopus-deploy-test/attributes/default.rb
+++ b/test/cookbooks/octopus-deploy-test/attributes/default.rb
@@ -23,7 +23,7 @@
 default['octopus-deploy-test']['server']['version'] = '2018.7.2'
 default['octopus-deploy-test']['server']['checksum'] = '89645C258354DE1C8038B5AD630E2EB8F3F1ECE096699A17300636BD116C2423'
 default['octopus-deploy-test']['server']['master-key'] = 'wJ+qLI8AjSvtdtIt05eW7w=='
-default['octopus-deploy-test']['server']['connection-string'] = 'Server=(local)\SQL2016;Database=master;User ID=sa;Password=Password12!'
+default['octopus-deploy-test']['server']['connection-string'] = 'Server=(local)\SQL2016;Database=OctopusDeploy;User ID=sa;Password=Password12!'
 
 # Tentacle test configuration
 default['octopus-deploy-test']['tentacle']['version'] = '3.22.0'

--- a/test/cookbooks/octopus-deploy-test/recipes/server.rb
+++ b/test/cookbooks/octopus-deploy-test/recipes/server.rb
@@ -25,6 +25,8 @@ octopus_deploy_server 'OctopusServer' do
   version node['octopus-deploy-test']['server']['version']
   checksum node['octopus-deploy-test']['server']['checksum']
   node_name 'octo-web-01'
+  user ENV['machine_user']
+  password ENV['machine_password']
   connection_string node['octopus-deploy-test']['server']['connection-string']
   master_key node['octopus-deploy-test']['server']['master-key']
   start_service node['octopus-deploy-test']['server']['start-service']


### PR DESCRIPTION
### Description

Bump versions of Octopus Server and Tentacle default install versions to support workers

### Issues Resolved

https://github.com/cvent/octopus-deploy-cookbook/issues/110

### Contribution Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README.
