### PR TITLE
Support workers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,9 @@ suites:
   - name: tentacle
     run_list:
       - recipe[octopus-deploy-test::tentacle]
+  - name: worker
+    run_list:
+      - recipe[octopus-deploy-test::worker]
   - name: tools
     run_list:
       - recipe[octopus-deploy-test::tools]

--- a/libraries/tentacle.rb
+++ b/libraries/tentacle.rb
@@ -48,8 +48,8 @@ module OctopusDeploy
       "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.#{version}-x64.msi"
     end
 
-    def tentacle_exists?(server, api_key, thumbprint)
-      ::JSON.parse(api_client(server, api_key).get("/machines/all?thumbprint=#{thumbprint}")).any? do |machine|
+    def tentacle_exists?(server, api_key, thumbprint, type = 'machines')
+      ::JSON.parse(api_client(server, api_key).get("/#{type}/all?thumbprint=#{thumbprint}")).any? do |machine|
         machine['Thumbprint'] == thumbprint
       end
     end

--- a/test/cookbooks/octopus-deploy-test/attributes/default.rb
+++ b/test/cookbooks/octopus-deploy-test/attributes/default.rb
@@ -20,14 +20,14 @@
 #
 
 # Server test configuration
-default['octopus-deploy-test']['server']['version'] = '3.2.24'
-default['octopus-deploy-test']['server']['checksum'] = 'fe82d0ebd4d0cc9baa38962d8224578154131856a3c3e63621e4834efa3006d7'
+default['octopus-deploy-test']['server']['version'] = '2018.7.2'
+default['octopus-deploy-test']['server']['checksum'] = '89645C258354DE1C8038B5AD630E2EB8F3F1ECE096699A17300636BD116C2423'
 default['octopus-deploy-test']['server']['master-key'] = 'wJ+qLI8AjSvtdtIt05eW7w=='
 default['octopus-deploy-test']['server']['connection-string'] = 'Server=(local)\SQL2016;Database=master;User ID=sa;Password=Password12!'
 
 # Tentacle test configuration
-default['octopus-deploy-test']['tentacle']['version'] = '3.19.0'
-default['octopus-deploy-test']['tentacle']['installer_url'] = 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.19.0-x64.msi'
-default['octopus-deploy-test']['tentacle']['checksum'] = 'a37b6c16494f16e7de03566de737a8c437267a227e287ed2f3f4d0ecab9eadee'
+default['octopus-deploy-test']['tentacle']['version'] = '3.22.0'
+default['octopus-deploy-test']['tentacle']['installer_url'] = 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.22.0-x64.msi'
+default['octopus-deploy-test']['tentacle']['checksum'] = '197AB79A95ADEE15AB0058BF0FA73D9E8AF2AA6AEF1741BEB39170C3A1D72CAB'
 default['octopus-deploy-test']['tentacle']['instance'] = 'Tentacle'
 default['octopus-deploy-test']['tentacle']['config_path'] = 'C:\\Octopus\\Tentacle.config'

--- a/test/cookbooks/octopus-deploy-test/recipes/worker.rb
+++ b/test/cookbooks/octopus-deploy-test/recipes/worker.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# Author:: Jamie Hopper (<jamiehopper341@gmail.com>)
+# Cookbook:: octopus-deploy-test
+# Recipe:: tentacle
+#
+# Copyright:: Copyright (c) 2015 Cvent, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+tentacle = node['octopus-deploy-test']['tentacle']
+
+# This section will mock out the certificate creation
+cert_directory = 'C:\Octopus Certificate'
+cert_file = File.join(cert_directory, 'tentacle_cert.txt')
+
+directory cert_directory
+
+cookbook_file cert_file do
+  action :create
+  source 'cert.txt'
+end
+
+# Just make sure its not installed already
+octopus_deploy_tentacle 'Uninstaller' do
+  action :uninstall
+  version tentacle['version']
+end
+
+# The configure action should also install the tentacle
+octopus_deploy_tentacle 'Worker' do
+  action [:remove, :configure]
+  version tentacle['version']
+  checksum tentacle['checksum']
+  trusted_cert '324JKSJKLSJ324DSFDF3423FDSF8783FDSFSDFS0'
+  cert_file cert_file
+end
+
+# Create a user to run the tentacle as (the cookbook assumes the user is already present)
+service_user = 'octopus_user'
+service_password = '5up3rR@nd0m'
+
+user service_user do
+  action :create
+  password service_password
+end
+
+octopus_deploy_tentacle 'register TentacleWithUser' do
+  action [:remove, :configure]
+  instance 'TentacleWithUser'
+  install_url tentacle['installer_url']
+  checksum tentacle['checksum']
+  polling true
+  trusted_cert '324JKSJKLSJ324DSFDF3423FDSF8783FDSFSDFS0'
+  service_user ".\\#{service_user}"
+  service_password service_password
+  home_path 'C:\OctopusWithUser'
+  config_path 'C:\OctopusWithUser\Tentacle.config'
+  app_path 'C:\OctopusWithUser\Applications'
+  cert_file cert_file
+  tenated_deployment_participation :Untenanted
+end


### PR DESCRIPTION
### Description

Adds register and uninstall worker actions to the `octopus_deploy_tentacle` resource.

### Issues Resolved

N/A

### Contribution Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README.
