### PR TITLE
compatibility-tentacle-5.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v0.13.3](https://github.com/cvent/octopus-deploy-cookbook/tree/v0.13.3) (2020-08-27)
+- Fix an issue with registering new tentacles with tentacle version 5.0.13 or above [\#173](https://github.com/cvent/octopus-deploy-cookbook/pull/173) ([NamanKumarCvent](https://github.com/NamanKumarCvent))
+- Updating gemlock on codecov to latest (0.2.8), anything prior to 0.2.0 is not supported [\#173](https://github.com/cvent/octopus-deploy-cookbook/pull/173) ([NamanKumarCvent](https://github.com/NamanKumarCvent))
+
+**Merged pull requests:**
+
 ## [v0.13.2](https://github.com/cvent/octopus-deploy-cookbook/tree/v0.13.2) (2019-04-09)
 [Full Changelog](https://github.com/cvent/octopus-deploy-cookbook/compare/v0.13.1...v0.13.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
     cleanroom (1.0.0)
-    codecov (0.1.16)
+    codecov (0.2.0)
       json
       simplecov
       url

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
     cleanroom (1.0.0)
-    codecov (0.2.0)
+    codecov (0.2.8)
       json
       simplecov
       url

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Handles installing Octopus Deploy Server &| Tentacle'
 source_url 'https://github.com/cvent/octopus-deploy-cookbook'
 issues_url 'https://github.com/cvent/octopus-deploy-cookbook/issues'
-version '0.13.2'
+version '0.13.3'
 
 depends 'windows'
 depends 'windows_firewall', '~> 3.0'

--- a/resources/tentacle.rb
+++ b/resources/tentacle.rb
@@ -84,16 +84,6 @@ action :configure do
     recursive true
   end
 
-  powershell_script "generate-tentacle-cert-#{new_resource.instance}" do
-    action :run
-    cwd tentacle_install_location
-    code <<-EOH
-      .\\Tentacle.exe new-certificate -e "#{new_resource.cert_file}" --console
-      #{catch_powershell_error('Generating Cert for the machine')}
-    EOH
-    not_if { new_resource.cert_file.nil? || ::File.exist?(new_resource.cert_file) }
-  end
-
   powershell_script "create-instance-#{new_resource.instance}" do
     action :run
     cwd tentacle_install_location
@@ -102,6 +92,16 @@ action :configure do
       #{catch_powershell_error('Creating instance')}
     EOH
     not_if { ::File.exist?(new_resource.config_path) }
+  end
+
+  powershell_script "generate-tentacle-cert-#{new_resource.instance}" do
+    action :run
+    cwd tentacle_install_location
+    code <<-EOH
+      .\\Tentacle.exe new-certificate -e "#{new_resource.cert_file}" --console
+      #{catch_powershell_error('Generating Cert for the machine')}
+    EOH
+    not_if { new_resource.cert_file.nil? || ::File.exist?(new_resource.cert_file) }
   end
 
   powershell_script "configure-tentacle-#{new_resource.instance}" do # ~FC009


### PR DESCRIPTION
### Description

With the newer version of the tentacle, it demands creating the instance before creating the cert. Hence switching the sequence

### Issues Resolved

When registering new windows deployment targets with Octo, the script started failing as it was expecting the instance to be created before the tentacle cert.

### Contribution Check List
- [x] All tests pass.
